### PR TITLE
Fix divide-by-zero

### DIFF
--- a/DBstats.c
+++ b/DBstats.c
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
     maxlen = db->maxlen;
     reads  = db->reads;
 
-    nbin  = (maxlen-1)/BIN + 1;
+    nbin  = (maxlen)/BIN + 1;
     hist  = (int *) Malloc(sizeof(int)*nbin,"Allocating histograms");
     bsum  = (int64 *) Malloc(sizeof(int64)*nbin,"Allocating histograms");
     if (hist == NULL || bsum == NULL)
@@ -151,7 +151,6 @@ int main(int argc, char *argv[])
         bsum[rlen/BIN] += rlen;
       }
 
-    nbin = (maxlen-1)/BIN + 1;
     ave  = totlen/nreads;
     dev  = 0;
     for (i = 0; i < nreads; i++)
@@ -230,7 +229,7 @@ int main(int argc, char *argv[])
                 printf(":");
                 Print_Number((int64) hist[i],11,stdout);
                 printf("    %5.1f    %5.1f   %9lld\n",(100.*cum)/nreads,
-                                                      (100.*btot)/totlen,btot/cum);
+                                                      (100.*btot)/totlen,(cum==0?0:(btot/cum)));
               }
             if (cum == nreads) break;
           }
@@ -306,7 +305,7 @@ int main(int argc, char *argv[])
                   printf(":");
                   Print_Number((int64) hist[k],11,stdout);
                   printf("        %5.1f    %5.1f   %9lld\n",(100.*cum)/numint,
-                                                        (100.*btot)/totlen,btot/cum);
+                                                        (100.*btot)/totlen,(cum==0?0:(btot/cum)));
                   if (cum == numint) break;
                 }
             }


### PR DESCRIPTION
This fixes several problems:

### Divide-by-zero when a bin is empty.
I don't care about 0 totlen or 0-length reads, but I do have a synthetic example with an unusual distribution of reads, such that some bins have none.

### Wrong number of bins.
There was a memory error (noted by **valgrind**), and all reads of maximum length were ignored, both because of a miscalculation. Suppose:
```
All reads in [0, 2000]. I.e. maxlen == 2000
BIN==1000, so we have 2 bins.
  Bin 0: [0, 999]
  Bin 1: [1000, 1999]
```
But what about the longest read? Its length is 2000, but there is no bin for it!

Possible solutions:
* Ignore 0-length reads.
  * But I'd like to see those also!
* Special-case 0-length reads, so bin-0 is slightly larger than the others.
  * Seems hard to code.
* Increase the number of bins.
  * In the case above, bin-2 will cover `[2000,2999]`, which seems fine.

### Duplicate line.