### PR TITLE
Divide-by-zero from `DBstats -mdust`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+*.d
+*.o
+*.a
+Catrack
+DAM2fasta
+DB2fasta
+DB2quiva
+DBdump
+DBdust
+DBrm
+DBshow
+DBsplit
+DBstats
+fasta2DAM
+fasta2DB
+quiva2DB
+simulator

--- a/DB.c
+++ b/DB.c
@@ -54,7 +54,7 @@ void *Malloc(int64 size, char *mesg)
 }
 
 void *Realloc(void *p, int64 size, char *mesg)
-{ if ((p = realloc(p,size)) == NULL)
+{ if ((size > 0) && ((p = realloc(p,size)) == NULL))
     { if (mesg == NULL)
         EPRINTF(EPLACE,"%s: Out of memory\n",Prog_Name);
       else

--- a/DB.h
+++ b/DB.h
@@ -98,7 +98,7 @@ extern char Ebuffer[];
 #define ARG_POSITIVE(var,name)                                                          \
   var = strtol(argv[i]+2,&eptr,10);                                                     \
   if (*eptr != '\0' || argv[i][2] == '\0')                                              \
-    { fprintf(stderr,"%s: -%c argument is not an integer\n",Prog_Name,argv[i][1]);      \
+    { fprintf(stderr,"%s: -%c '%s' argument is not an integer\n",Prog_Name,argv[i][1],argv[i]+2);      \
       exit (1);                                                                         \
     }                                                                                   \
   if (var <= 0)                                                                         \
@@ -109,18 +109,18 @@ extern char Ebuffer[];
 #define ARG_NON_NEGATIVE(var,name)                                                      \
   var = strtol(argv[i]+2,&eptr,10);                                                     \
   if (*eptr != '\0' || argv[i][2] == '\0')                                              \
-    { fprintf(stderr,"%s: -%c argument is not an integer\n",Prog_Name,argv[i][1]);      \
+    { fprintf(stderr,"%s: -%c '%s' argument is not an integer\n",Prog_Name,argv[i][1],argv[i]+2);      \
       exit (1);                                                                         \
     }                                                                                   \
   if (var < 0)	                                                                        \
-    { fprintf(stderr,"%s: %s must be non-negative (%d)\n",Prog_Name,name,var);          \
+    { fprintf(stderr,"%s: %s '%s' must be non-negative (%d)\n",Prog_Name,name,argv[i]+2,var);          \
       exit (1);                                                                         \
     }
 
 #define ARG_REAL(var)                                                                   \
   var = strtod(argv[i]+2,&eptr);                                                        \
   if (*eptr != '\0' || argv[i][2] == '\0')                                              \
-    { fprintf(stderr,"%s: -%c argument is not a real number\n",Prog_Name,argv[i][1]);   \
+    { fprintf(stderr,"%s: -%c '%s' argument is not a real number\n",Prog_Name,argv[i][1],argv[i]+2);   \
       exit (1);                                                                         \
     }
 

--- a/DBstats.c
+++ b/DBstats.c
@@ -254,7 +254,7 @@ int main(int argc, char *argv[])
 
   { int64      totlen;
     int        numint, maxlen;
-    int64      ave, dev;
+    //int64      ave, dev;
     HITS_TRACK *track;
 
     for (track = db->tracks; track != NULL; track = track->next)
@@ -284,18 +284,18 @@ int main(int argc, char *argv[])
             bsum[k] = 0;
           }
 
-        ave  = totlen/numint;
-        dev  = 0;
+        //ave  = totlen/numint;
+        //dev  = 0;
         for (k = 0; k < db->nreads; k++)
           { edata = (int *) (data + anno[k+1]);
             for (idata = (int *) (data + anno[k]); idata < edata; idata += 2)
               { rlen = idata[1] - *idata;
-                dev += (rlen-ave)*(rlen-ave);
+                //dev += (rlen-ave)*(rlen-ave);
                 hist[rlen/BIN] += 1;
                 bsum[rlen/BIN] += rlen;
               }
           }
-        dev = (int64) sqrt((1.*dev)/numint);
+        //dev = (int64) sqrt((1.*dev)/numint);
 
         printf("\n\nStatistics for %s-track\n",track->name);
 

--- a/QV.h
+++ b/QV.h
@@ -14,6 +14,7 @@
 #ifndef _QV_COMPRESSOR
 
 #define _QV_COMPRESSOR
+#include <stdio.h>
 
   //  The defined constant INTERACTIVE (set in DB.h) determines whether an interactive or
   //    batch version of the routines in this library are compiled.  In batch mode, routines


### PR DESCRIPTION
* When I use **DBdust** with a high enough `-t` that there is no "dust" found, `DBstats -mdust` crashes on calculating the average dust length. `ave` and `dev` are not even used there, so I've removed them.
* After that change, there is an *Out of memory* reported for `realloc()` on a zero-size array, via `Trim_DB()`. (I don't know why that happens only for the case of empty dust tracks.)
```
#0  Realloc (p=0x612090, size=0, mesg=0x0) at DB.c:57
#1  0x00000000004049ab in Trim_DB (db=0x7fffffffe300) at DB.c:621
#2  0x0000000000401834 in main (argc=2, argv=0x7fffffffe668) at DBstats.c:112
```
* I've also added `<stdio.h>` in a file that technically needs it. (That is useful for a [**Nim**](http://nim-lang.org/) wrapper I am writing for **DAZZ_DB**.)
* Finally, I've added a proper `.gitignore`, to make `git add .` work better.