### PR TITLE
Fix a typo in Catrack.c

### DIFF
--- a/Catrack.c
+++ b/Catrack.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
           break;
         dfile = fopen(Numbered_Suffix(prefix,nfiles+1,Catenate(".",argv[2],".","data")),"r");
 
-        if (nfile > 0)
+        if (nfiles > 0)
           fclose(lfile);
         lfile = afile;
 


### PR DESCRIPTION
This PR fix a small typo with a missing 's' in Catrack.c
