### PR TITLE
ONElib.c: fully declare vasprintf.

### DIFF
--- a/ONElib.c
+++ b/ONElib.c
@@ -16,8 +16,10 @@
  *
  ****************************************************************************************/
 
+#define _GNU_SOURCE
 #include <sys/errno.h>
 #include <sys/types.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>


### PR DESCRIPTION
Per vasprintf(3) manual, the function needs _GNU_SOURCE definiton for proper declaration.  As seen in [Debian bug #1066663], lack thereof causes build failures with -Werror=implicit-function-declaration.

[Debian bug #1066663]: https://bugs.debian.org/1066663